### PR TITLE
Add "drag_area" for hit detection

### DIFF
--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -576,18 +576,22 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 
 	Ref<StyleBoxFlat> style_tab_selected = style_widget->duplicate();
 	style_tab_selected->set_border_width_all(0);
-	style_tab_selected->set_corner_radius_individual(corner_radius, corner_radius, 0, 0);
+	style_tab_selected->set_corner_radius_all(0);
+	style_tab_selected->set_border_width(MARGIN_TOP, 2 * EDSCALE);
 	style_tab_selected->set_expand_margin_size(MARGIN_BOTTOM, corner_radius * EDSCALE);
 	style_tab_selected->set_default_margin(MARGIN_LEFT, tab_default_margin_side);
 	style_tab_selected->set_default_margin(MARGIN_RIGHT, tab_default_margin_side);
 	style_tab_selected->set_default_margin(MARGIN_BOTTOM, tab_default_margin_vertical);
 	style_tab_selected->set_default_margin(MARGIN_TOP, tab_default_margin_vertical);
+	style_tab_selected->set_border_color(accent_color);
 	style_tab_selected->set_bg_color(base_color);
 
 	Ref<StyleBoxFlat> style_tab_unselected = style_tab_selected->duplicate();
+	style_tab_unselected->set_border_width_all(0);
+	style_tab_unselected->set_corner_radius_individual(corner_radius, corner_radius, 0, 0);
 	style_tab_unselected->set_bg_color(dark_color_1);
 
-	Ref<StyleBoxFlat> style_tab_disabled = style_tab_selected->duplicate();
+	Ref<StyleBoxFlat> style_tab_disabled = style_tab_unselected->duplicate();
 	style_tab_disabled->set_bg_color(color_disabled_bg);
 
 	Ref<StyleBoxFlat> style_scene_tab_selected = style_widget->duplicate();
@@ -617,7 +621,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 
 	// Menu
 	Ref<StyleBoxFlat> style_menu = style_widget->duplicate();
-	style_menu->set_draw_center(false);
+	style_menu->set_draw_center(true);
 	style_menu->set_border_width_all(0);
 	theme->set_stylebox("panel", "PanelContainer", style_menu);
 	theme->set_stylebox("MenuPanel", "EditorStyles", style_menu);
@@ -826,7 +830,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	style_property_bg->set_bg_color(highlight_color);
 	style_property_bg->set_border_width_all(0);
 
-	theme->set_constant("font_offset", "EditorProperty", 1 * EDSCALE);
+	theme->set_constant("font_offset", "EditorProperty", 12 * EDSCALE);
 	theme->set_stylebox("bg_selected", "EditorProperty", style_property_bg);
 	theme->set_stylebox("bg", "EditorProperty", Ref<StyleBoxEmpty>(memnew(StyleBoxEmpty)));
 	theme->set_constant("vseparation", "EditorProperty", (extra_spacing + default_margin_size) * EDSCALE);
@@ -1046,8 +1050,10 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_icon("grabber", "VSplitContainer", theme->get_icon("GuiVsplitter", "EditorIcons"));
 	theme->set_icon("grabber", "HSplitContainer", theme->get_icon("GuiHsplitter", "EditorIcons"));
 
-	theme->set_constant("separation", "HSplitContainer", default_margin_size * 2 * EDSCALE);
-	theme->set_constant("separation", "VSplitContainer", default_margin_size * 2 * EDSCALE);
+	theme->set_constant("separation", "HSplitContainer", default_margin_size * EDSCALE);
+	theme->set_constant("separation", "VSplitContainer", default_margin_size * EDSCALE);
+	theme->set_constant("drag_area", "HSplitContainer", default_margin_size * 2 * EDSCALE);
+	theme->set_constant("drag_area", "VSplitContainer", default_margin_size * 2 * EDSCALE);
 
 	// Containers
 	theme->set_constant("separation", "BoxContainer", default_margin_size * EDSCALE);

--- a/scene/gui/split_container.cpp
+++ b/scene/gui/split_container.cpp
@@ -77,8 +77,7 @@ void SplitContainer::_resort() {
 
 	// Determine the separation between items
 	Ref<Texture> g = get_icon("grabber");
-	int sep = get_constant("separation");
-	sep = (dragger_visibility != DRAGGER_HIDDEN_COLLAPSED) ? MAX(sep, vertical ? g->get_height() : g->get_width()) : 0;
+	int sep = (dragger_visibility != DRAGGER_HIDDEN_COLLAPSED) ? get_constant("separation") : 0;
 
 	// Compute the minimum size
 	Size2 ms_first = first->get_combined_minimum_size();
@@ -109,11 +108,11 @@ void SplitContainer::_resort() {
 
 	if (vertical) {
 		fit_child_in_rect(first, Rect2(Point2(0, 0), Size2(get_size().width, middle_sep)));
-		int sofs = middle_sep + sep;
+		int sofs = middle_sep + (collapsed ? 0 : sep);
 		fit_child_in_rect(second, Rect2(Point2(0, sofs), Size2(get_size().width, get_size().height - sofs)));
 	} else {
 		fit_child_in_rect(first, Rect2(Point2(0, 0), Size2(middle_sep, get_size().height)));
-		int sofs = middle_sep + sep;
+		int sofs = middle_sep + (collapsed ? 0 : sep);
 		fit_child_in_rect(second, Rect2(Point2(sofs, 0), Size2(get_size().width - sofs, get_size().height)));
 	}
 
@@ -207,16 +206,18 @@ void SplitContainer::_gui_input(const Ref<InputEvent> &p_event) {
 	if (mb.is_valid()) {
 		if (mb->get_button_index() == BUTTON_LEFT) {
 			if (mb->is_pressed()) {
-				int sep = get_constant("separation");
+				const int drag_area = get_constant("drag_area");
+				const int sep = (dragger_visibility != DRAGGER_HIDDEN_COLLAPSED) ? get_constant("separation") : 0;
+				const int center = middle_sep + sep / 2;
 
 				if (vertical) {
-					if (mb->get_position().y > middle_sep && mb->get_position().y < middle_sep + sep) {
+					if (mb->get_position().y >= (center - drag_area) && mb->get_position().y <= (center + drag_area)) {
 						dragging = true;
 						drag_from = mb->get_position().y;
 						drag_ofs = split_offset;
 					}
 				} else {
-					if (mb->get_position().x > middle_sep && mb->get_position().x < middle_sep + sep) {
+					if (mb->get_position().x >= (center - drag_area) && mb->get_position().x <= (center + drag_area)) {
 						dragging = true;
 						drag_from = mb->get_position().x;
 						drag_ofs = split_offset;
@@ -231,11 +232,14 @@ void SplitContainer::_gui_input(const Ref<InputEvent> &p_event) {
 	Ref<InputEventMouseMotion> mm = p_event;
 
 	if (mm.is_valid()) {
+		const int drag_area = get_constant("drag_area");
+		const int sep = (dragger_visibility != DRAGGER_HIDDEN_COLLAPSED) ? get_constant("separation") : 0;
+		const int center = middle_sep + sep / 2;
 		bool mouse_inside_state = false;
 		if (vertical) {
-			mouse_inside_state = mm->get_position().y > middle_sep && mm->get_position().y < middle_sep + get_constant("separation");
+			mouse_inside_state = mm->get_position().y >= (center - drag_area) && mm->get_position().y <= (center + drag_area);
 		} else {
-			mouse_inside_state = mm->get_position().x > middle_sep && mm->get_position().x < middle_sep + get_constant("separation");
+			mouse_inside_state = mm->get_position().x >= (center - drag_area) && mm->get_position().x <= (center + drag_area);
 		}
 
 		if (mouse_inside != mouse_inside_state) {
@@ -262,14 +266,15 @@ Control::CursorShape SplitContainer::get_cursor_shape(const Point2 &p_pos) const
 	}
 
 	if (!collapsed && _getch(0) && _getch(1) && dragger_visibility == DRAGGER_VISIBLE) {
-		int sep = get_constant("separation");
-
+		const int drag_area = get_constant("drag_area");
+		const int sep = (dragger_visibility != DRAGGER_HIDDEN_COLLAPSED) ? get_constant("separation") : 0;
+		const int center = middle_sep + sep / 2;
 		if (vertical) {
-			if (p_pos.y > middle_sep && p_pos.y < middle_sep + sep) {
+			if (p_pos.y >= (center - drag_area) && p_pos.y <= (center + drag_area)) {
 				return CURSOR_VSPLIT;
 			}
 		} else {
-			if (p_pos.x > middle_sep && p_pos.x < middle_sep + sep) {
+			if (p_pos.x >= (center - drag_area) && p_pos.x <= (center + drag_area)) {
 				return CURSOR_HSPLIT;
 			}
 		}

--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -902,6 +902,8 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_constant("vseparation", "GridContainer", 4 * scale);
 	theme->set_constant("separation", "HSplitContainer", 12 * scale);
 	theme->set_constant("separation", "VSplitContainer", 12 * scale);
+	theme->set_constant("drag_area", "HSplitContainer", 12 * scale);
+	theme->set_constant("drag_area", "VSplitContainer", 12 * scale);
 	theme->set_constant("autohide", "HSplitContainer", 1);
 	theme->set_constant("autohide", "VSplitContainer", 1);
 	theme->set_constant("hseparation", "HFlowContainer", 4 * scale);


### PR DESCRIPTION
- Decouple separator and hit detector
- Add "drag_area" for hit detection

This Allow the SplitContainer separator to be narrow

> [!NOTE]
> Since this Node will be a `parent` for other node, the hit detection may be blocked by its childern, Use `MOUSE_FILTER_PASS` if you wanted to get whole drag_area detector working.

![image](https://github.com/user-attachments/assets/884370ad-d62e-4609-b9b7-cf4b9d1fc496)

![image](https://github.com/user-attachments/assets/54a5c595-b75a-4e90-a88e-ccb509ac4d40)

