### PR TITLE
Main & EditorNode adjustment

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -3159,6 +3159,7 @@ void EditorNode::_discard_changes(const String &p_str) {
 			}
 		} break;
 		case FILE_QUIT: {
+			OS::get_singleton()->set_window_minimized(true);
 			_menu_option_confirm(RUN_STOP, true);
 			_exit_editor();
 

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1502,7 +1502,7 @@ Error Main::setup2(Thread::ID p_main_tid_override) {
 
 	MAIN_PRINT("Main: Load Boot Image");
 
-	Color clear = GLOBAL_DEF("rendering/environment/default_clear_color", Color(0.2, 0.2, 0.2));
+	Color clear = GLOBAL_DEF("rendering/environment/default_clear_color", Color(0.3, 0.3, 0.3));
 	VisualServer::get_singleton()->set_default_clear_color(clear);
 
 	if (show_logo) { //boot logo!


### PR DESCRIPTION
- [EditorNode: Minimize when exit](https://github.com/naiiveprojects/GDX/commit/e2aef456fbc45570c12348c48ca47143e0c9dedb), this can make the program feel faster, i remember when i closing unreal engine it close immediately, while archiving that in godot may take some works, this simple approach give almost the same impression.
- [Main: Fix mixed default_clear_color](https://github.com/naiiveprojects/GDX/commit/b9390a0105e776b764e56de570432c625929f25a)